### PR TITLE
fix: remove unused FilesystemError import in datafile()

### DIFF
--- a/clu/exporting.py
+++ b/clu/exporting.py
@@ -534,9 +534,7 @@ class ExporterBase(collections.abc.MutableMapping,
     
     def datafile(self):
         """ Return a unique filename for this instance """
-        from clu.fs.appdirectories import AppDirs
-        from clu.constants.exceptions import FilesystemError
-        
+        from clu.fs.appdirectories import AppDirs        
         # Initialize an AppDirs instance:
         appdirs = AppDirs(appname=type(self).appname)
         


### PR DESCRIPTION
The `FilesystemError` exception was imported from `clu.constants.exceptions` on line 538 but was never used in the `datafile()` method. This commit removes the unused import to clean up the code.

Fixes #16