### PR TITLE
ci: Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+        pip install pytest pytest-cov coverage
+
+    - name: Run tests with coverage
+      run: |
+        pytest tests/ -v --cov=clu --cov-report=xml --cov-report=term-missing
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        file: ./coverage.xml
+        fail_ci_if_error: false
+        verbose: true
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install linting tools
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pylint
+
+    - name: Lint with flake8
+      run: |
+        flake8 clu/ --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 clu/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics


### PR DESCRIPTION
## Summary
This PR addresses #23 by implementing a comprehensive GitHub Actions CI workflow for the CLU project.

## Changes
Added `.github/workflows/ci.yml` with:

### Test Job
- Runs on Ubuntu and macOS
- Tests against Python 3.8, 3.9, 3.10, 3.11, and 3.12
- Installs project dependencies with `pip install -e .[dev]`
- Runs pytest with coverage reporting
- Uploads coverage reports to Codecov

### Lint Job
- Runs on Ubuntu with Python 3.11
- Installs flake8 and pylint
- Runs flake8 for code style checking

### Triggers
- Push events to `master` and `main` branches
- Pull request events targeting `master` and `main` branches

Closes #23